### PR TITLE
:bug: containsKey on wrong key

### DIFF
--- a/packages/dart/lib/src/objects/parse_user.dart
+++ b/packages/dart/lib/src/objects/parse_user.dart
@@ -474,7 +474,7 @@ class ParseUser extends ParseObject implements ParseCloneable {
         handleResponse<ParseUser>(user, response, type, debug, className);
 
     final Map<String, dynamic> responseData = jsonDecode(response.data);
-    if (responseData.containsKey(keyVarObjectId)) {
+    if (responseData.containsKey(keyParamSessionToken)) {
       user.sessionToken = responseData[keyParamSessionToken];
       ParseCoreData().setSessionId(user.sessionToken);
     }


### PR DESCRIPTION
The containsKey check is on the wrong key (keyVarObjectId) instead of (keyParamSessionToken) - therefore it fails on null safety, if the sessionToken is not provided in responseData (for example in case of signUp)